### PR TITLE
Update Lang.ts

### DIFF
--- a/src/utility/Lang.ts
+++ b/src/utility/Lang.ts
@@ -2106,6 +2106,18 @@ namespace TinyWars.Utility.Lang {
             `公共(中文)`,
             `Public(CN)`,
         ],
+        [Type.B0385]: [
+            `请输入房间密码`,
+            `Please enter the password`,
+        ],
+        [Type.B0386]: [
+            `密码`, ////`私人房间`？////
+            `Private`,
+        ],
+        [Type.B0387]: [  ////can be deleted if B0185 is used in the fix. See also change note////
+            `房间`,
+            `Game`,
+        ],
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////
         [Type.B1000]: [


### PR DESCRIPTION
Data for #119
B0385, B0386 and B0387 is added. B0387 can be deleted if B0185 is used for the fix. 

`密码` is translated in B0171. B0186 can also be used. （房间密码Game Password）
`房间` can also use B0185. （房间名称Game Name）
`确定` can use B0026. 
`返回` can use B0146 or B0154 （取消Cancel）.